### PR TITLE
fix typo

### DIFF
--- a/startup-prod.sh
+++ b/startup-prod.sh
@@ -24,7 +24,7 @@ sed -i.bak "s%@@UBIRCH_TR_ENV_SERVURL@@%${UBIRCH_TR_ENV_SERVURL}%" src/environme
 echo "Replacing variables UBIRCH_TR_API_PREF in src/environments/environment.ts"
 sed -i.bak "s%@@UBIRCH_TR_API_PREF@@%${UBIRCH_TR_API_PREF}%" src/environments/environment.ts
 
-echo "Replacing variables UBIRCHy f_TR_CLIENT_NAME in src/environments/environment.ts"
+echo "Replacing variables UBIRCH_TR_CLIENT_NAME in src/environments/environment.ts"
 sed -i.bak "s%@@UBIRCH_TR_CLIENT_NAME@@%${UBIRCH_TR_CLIENT_NAME}%" src/environments/environment.ts
 
 echo "Replacing variables UBIRCH_TR_DEFAULT_DEVICE_TYPE in src/environments/environment.ts"


### PR DESCRIPTION
In f1a18cbd461ef3760c9d59e8dce418d5694f0348 this was accidentally changed, this commit reverts the log output to the old version.