### PR TITLE
fix preprocess

### DIFF
--- a/startup-prod.sh
+++ b/startup-prod.sh
@@ -2,7 +2,7 @@
 
 env
 
-bash preprocess4client.sh UBIRCH_TR_KC_REALM
+bash preprocess4client.sh "${UBIRCH_TR_KC_REALM}"
 rm src/environments/environment.ts
 mv src/environments/environment.prod.ts src/environments/environment.ts
 


### PR DESCRIPTION
preprocess4client.sh takes an argument, generating a default configuration if it doesnt already exist.
this value was not read from the environment values, but did always evaluate to the string "UBIRCH_TR_KC_REALM" instead.
This commit attempts to fix this behaviour