### PR TITLE
Use k8s secrets references

### DIFF
--- a/helm-charts/web-ui/templates/deployment.yaml
+++ b/helm-charts/web-ui/templates/deployment.yaml
@@ -39,11 +39,20 @@ spec:
             - name: UBIRCH_KC_URL
               value: {{ .Values.adminUi.keyCloak.url }}
             - name: UBIRCH_TR_KC_REALM
-              value: {{ .Values.adminUi.keyCloak.testRealm.realmName }}
+              valueFrom:
+                secretKeyRef:
+                  name: ubs.admin-ui
+                  key: realm
             - name: UBIRCH_KC_CLIENTID
-              value: {{ .Values.adminUi.keyCloak.clientId }}
+              valueFrom:
+                secretKeyRef:
+                  name: ubs.admin-ui
+                  key: client_id
             - name: UBIRCH_TR_KC_CRED_SECRET
-              value: {{ .Values.adminUi.keyCloak.testRealm.secret }}
+              valueFrom:
+                secretKeyRef:
+                  name: ubs.admin-ui
+                  key: password
             - name: UBIRCH_TR_ENV_SERVURL
               value: {{ .Values.adminUi.env.serverUrl }}
             - name: UBIRCH_TR_API_PREF

--- a/helm-charts/web-ui/values.demo.yaml
+++ b/helm-charts/web-ui/values.demo.yaml
@@ -32,10 +32,7 @@ ingress:
 adminUi:
   keyCloak:
     url: "https://id.demo.ubirch.com/auth"
-    clientId: "ubirch-2.0-user-access"
     testRealm:
-      realmName: "ubirch-default-realm"
-      secret: "72364be2-dc60-4978-b9a4-5930a0238255"
       clientName: "ubirch GmbH"
       defaultDeviceType: "default_type"
 

--- a/helm-charts/web-ui/values.dev.yaml
+++ b/helm-charts/web-ui/values.dev.yaml
@@ -32,10 +32,7 @@ ingress:
 adminUi:
   keyCloak:
     url: "https://id.dev.ubirch.com/auth"
-    clientId: "ubirch-2.0-user-access"
     testRealm:
-      realmName: "ubirch-default-realm"
-      secret: "425bae4e-1904-4a6b-b977-f26fc0590ccc"
       clientName: "ubirch GmbH"
       defaultDeviceType: "default_type"
 


### PR DESCRIPTION
This commit replaces the literal passwords in the configuration
with references to kubernetes secrets.