### PR TITLE
Fix ingress on demo not issuing certificate

### DIFF
--- a/helm-charts/web-ui/values.demo.yaml
+++ b/helm-charts/web-ui/values.demo.yaml
@@ -18,8 +18,8 @@ ingress:
   enabled: enable
   annotations:
     certmanager.k8s.io/acme-challenge-type: "dns01"
-    certmanager.k8s.io/cluster-issuer: "letsencrypt-dev"
-    certmanager.k8s.io/acme-dns01-provider: "dev-dns"
+    certmanager.k8s.io/cluster-issuer: "letsencrypt-demo"
+    certmanager.k8s.io/acme-dns01-provider: "demo-dns-demo-ubirch-com"
     kubernetes.io/ingress.allow-http: "false"
   path: /
   hosts:
@@ -39,7 +39,7 @@ adminUi:
   env:
     serverUrl: "https://api.console.demo.ubirch.com"
     apiPrefix: "/ubirch-web-ui/api/v1/"
-      keyserviceUrl: "https://key.demo.ubirch.com"
+    keyserviceUrl: "https://key.demo.ubirch.com"
     keyservicePrefix: "/api/keyService/v1/"
     trustserviceUrl: "https://verify.prod.ubirch.com"
     verifyPrefix: "/api/verify/"


### PR DESCRIPTION
This PR enables the TLS certificate again for http://console.demo.ubirch.com