### PR TITLE
Change the IOTA explorer

### DIFF
--- a/resources/blockchain-settings.json
+++ b/resources/blockchain-settings.json
@@ -31,10 +31,10 @@
       "nodeIcon": "IOTA_verify_right.png",
       "explorerUrl": {
         "testnet": {
-          "url": "https://comnet.thetangle.org/transaction/"
+          "url": "https://explorer.iota.org/devnet/transaction/"
         },
         "mainnet": {
-          "url": "https://thetangle.org/transaction/"
+          "url": "https://explorer.iota.org/mainnet/transaction/"
         }
       }
     },


### PR DESCRIPTION
Hi,
really appreciate your work and contribution to the IOTA ecosystem.
I changed the IOTA explorer to the official one, managed by the IOTA foundation.
Also, for testing you should use the devnet. The comnet isn't online all the time.